### PR TITLE
Fix OpenAPI spec path for test compatibility

### DIFF
--- a/Maliev.CareerService.Api/Program.cs
+++ b/Maliev.CareerService.Api/Program.cs
@@ -271,7 +271,7 @@ try
     // Configure OpenAPI spec endpoint and Scalar UI (interactive API documentation)
     app.UseSwagger(options =>
     {
-        options.RouteTemplate = "careers/openapi/{documentName}.json";
+        options.RouteTemplate = "career/swagger/{documentName}/swagger.json";
     });
 
     app.MapScalarApiReference(options =>
@@ -280,7 +280,7 @@ try
             .WithTitle("Maliev Career Service API")
             .WithTheme(ScalarTheme.Saturn)
             .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
-            .WithOpenApiRoutePattern("/careers/openapi/{documentName}.json")
+            .WithOpenApiRoutePattern("/career/swagger/{documentName}/swagger.json")
             .WithEndpointPrefix("/careers/scalar/{documentName}");
     });
 


### PR DESCRIPTION
## Summary
- Updates OpenAPI spec path from `/careers/openapi/v1.json` to `/career/swagger/v1/swagger.json`
- Fixes 12 OpenAPI spec contract test failures
- Maintains Scalar UI for API documentation (no Swagger UI)

## Changes
- Modified `UseSwagger()` route template to match test expectations
- Updated Scalar UI OpenAPI pattern to match new path

## Test Plan
- [ ] All IDP contract tests pass
- [ ] OpenAPI spec accessible at expected path
- [ ] Scalar UI continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)