### PR TITLE
test: refresh CareerService test tooling

### DIFF
--- a/Maliev.CareerService.Tests/Maliev.CareerService.Tests.csproj
+++ b/Maliev.CareerService.Tests/Maliev.CareerService.Tests.csproj
@@ -13,16 +13,16 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.8.1" />
     <PackageReference Include="Testcontainers.Redis" Version="4.8.1" />
     <PackageReference Include="Testcontainers.RabbitMq" Version="4.8.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Refreshes only the test runner and coverage tooling on the current develop tree:

- Microsoft.NET.Test.Sdk 18.8.1
- xunit.runner.visualstudio 3.1.5
- coverlet.collector 10.0.1

Validation:
- Exact hosted package mode using the workflow-frozen MessagingContracts and Aspire sources: Release build 0 warnings/errors
- Full test suite: 246/246 passed
- No vulnerable packages reported
- Scoped end-of-file/trailing-whitespace hooks and git diff check passed

The ordinary local source-project mode still encounters the repository's existing ServiceDefaults EF 10.0.5 versus service EF 10.0.10 mismatch; this PR does not alter that dependency boundary, and the exact CI package mode is green.